### PR TITLE
X670 : fix reboot to bootloader while booting GSI

### DIFF
--- a/twrp_X670.mk
+++ b/twrp_X670.mk
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# Installs gsi keys into ramdisk, to boot a developer GSI with verified boot.
+$(call inherit-product, $(SRC_TARGET_DIR)/product/gsi_keys.mk)
+
 # Inherit some common twrp stuff.
 $(call inherit-product, vendor/twrp/config/common.mk)
 


### PR DESCRIPTION
Installs gsi keys into ramdisk, to boot a developer GSI with verified boot.